### PR TITLE
add a description

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Puppeteer is a Node library which provides a high-level API to control Chromium or Chrome over the DevTools Protocol." />
 
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-106086244-2"></script>


### PR DESCRIPTION
While google a more logical description when none is available, not all search engines do so.
Here's how the website search result looks on [duckduckgo](https://duckduckgo.com/?q=pptr+dev&ia=software).
![image](https://user-images.githubusercontent.com/20256683/83423405-8be71800-a448-11ea-80a4-17532dc5194f.png)

Hence, tried adding an appropriate description to make things a little more consistent.
![image](https://user-images.githubusercontent.com/20256683/83423488-aae5aa00-a448-11ea-8595-2f8184c8714a.png)

