### PR TITLE
fix(settings): fix undefined values for Chromium versions

### DIFF
--- a/src/pptr/PPTRProduct.js
+++ b/src/pptr/PPTRProduct.js
@@ -97,7 +97,6 @@ export class PPTRProduct extends App.Product {
       } else if (release.name === 'v8.0.0') {
         release.chromiumVersion = 'Chromium 90.0.4427.0 (r856583)';
       }
-
     }
 
     // Add tip-of-tree version.

--- a/src/pptr/PPTRProduct.js
+++ b/src/pptr/PPTRProduct.js
@@ -73,6 +73,7 @@ export class PPTRProduct extends App.Product {
     }
 
     // Fill predefined chromium versions for past releases:
+    // If the regex parse would fail version pairs can be retrieved from: https://github.com/puppeteer/puppeteer/blob/main/versions.js
     for (const release of releases) {
       if (release.name === 'v0.9.0') {
         release.chromiumVersion = 'Chromium 62.0.3188.0 (r494755)';
@@ -84,6 +85,14 @@ export class PPTRProduct extends App.Product {
         release.chromiumVersion = 'Chromium 66.0.3347.0 (r536395)';
       } else if (release.name === 'v1.3.0') {
         release.chromiumVersion = 'Chromium 67.0.3392.0 (r536395)';
+      } else if (release.name === 'v5.1.0') {
+        release.chromiumVersion = 'Chromium 84.0.4147.0 (r768783)';
+      } else if (release.name === 'v5.5.0') {
+        release.chromiumVersion = 'Chromium 88.0.4298.0 (r818858)';
+      } else if (release.name === 'v6.0.0') {
+        release.chromiumVersion = 'Chromium 89.0.4389.0 (r843427)';
+      } else if (release.name === 'v7.0.0') {
+        release.chromiumVersion = 'Chromium 90.0.4403.0 (r848005)';
       }
     }
 
@@ -102,6 +111,8 @@ export class PPTRProduct extends App.Product {
       const match = release.releaseNotes.match(/Chromium\s+(\d+\.\d+.\d+.\d+)\s*\((r\d{6})\)/i);
       if (match)
         release.chromiumVersion = `Chromium ${match[1]} (${match[2]})`;
+      else
+        release.chromiumVersion = 'N/A'
     }
 
     // Download api.md for every release.

--- a/src/pptr/PPTRProduct.js
+++ b/src/pptr/PPTRProduct.js
@@ -74,6 +74,7 @@ export class PPTRProduct extends App.Product {
 
     // Fill predefined chromium versions for past releases:
     // If the regex parse would fail version pairs can be retrieved from: https://github.com/puppeteer/puppeteer/blob/main/versions.js
+    // or https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#puppeteer-api-tip-of-tree
     for (const release of releases) {
       if (release.name === 'v0.9.0') {
         release.chromiumVersion = 'Chromium 62.0.3188.0 (r494755)';
@@ -93,7 +94,10 @@ export class PPTRProduct extends App.Product {
         release.chromiumVersion = 'Chromium 89.0.4389.0 (r843427)';
       } else if (release.name === 'v7.0.0') {
         release.chromiumVersion = 'Chromium 90.0.4403.0 (r848005)';
+      } else if (release.name === 'v8.0.0') {
+        release.chromiumVersion = 'Chromium 90.0.4427.0 (r856583)';
       }
+
     }
 
     // Add tip-of-tree version.


### PR DESCRIPTION
**Description:** Since a while there are `undefined` values in the Chromium column of the _Settings_ component. 
I summarized the cause of the problem here: https://github.com/puppeteer/pptr.dev/issues/20#issuecomment-776271813

**Before:**  ❌ 
![before](https://user-images.githubusercontent.com/43063460/107585847-35e58980-6bff-11eb-8c2d-21b2e453bf91.png)

**After:**  ✔️ 
![after](https://user-images.githubusercontent.com/43063460/107585907-4b5ab380-6bff-11eb-9747-07306b67d5ad.png)

@jackfranklin @johanbay can you take a look please? I am aware the fix is not perfect, but still better than how it looks now.  I will raise an issue in the [puppeteer repo](https://github.com/puppeteer/puppeteer) suggesting to use the Chromium versions in release notes that are recognized by the regex pattern.

_Note:_ I did not create **production build** as I faced issues with workbox-build: in case my PR would be accepted, please do the `npm run build` on the branch. (Was able to test the prod build anyway, only struggled with bumping the revision in sw.js 😅 )



closes #20 